### PR TITLE
feat: add max width for web view

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -96,7 +96,7 @@ const Home: NextPage = () => {
                   open={true}
                   arrow
                   title="User name: admin, pwd: admin"
-                  placement="top"
+                  placement="top-end"
                 >
                   <Typography variant="subtitle2">Name</Typography>
                 </Tooltip>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -3,7 +3,8 @@
 html,
 body {
   padding: 0;
-  margin: 0;
+  margin: auto;
+  max-width: 500px;
   font-family:
     -apple-system,
     BlinkMacSystemFont,


### PR DESCRIPTION
draft to fix #63 

issue: tooltip sitting outside of view.

![image](https://github.com/Greenstand/treetracker-web-map-core-demo/assets/61099792/6b93789d-38b7-4556-9da4-9152610f1186)
